### PR TITLE
PlatformIO Example

### DIFF
--- a/example/platformio/boards/bleeptrack_picoplanet.json
+++ b/example/platformio/boards/bleeptrack_picoplanet.json
@@ -1,0 +1,58 @@
+{
+  "build": {
+    "arduino": {
+        "ldscript": "flash_with_bootloader.ld"
+    },
+    "core": "adafruit",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DPICOPLANET -DARDUINO_TRINKET_M0 -DCRYSTALLESS -DADAFRUIT_TRINKET_M0 -DARM_MATH_CM0PLUS -D__SAMD21E18A__",
+    "f_cpu": "48000000L",
+    "hwids": [
+      [
+        "0x239A",
+        "0x801E"
+      ],
+      [
+        "0x239A",
+        "0x001E"
+      ]
+    ],
+    "mcu": "samd21e18a",
+    "system": "samd",
+    "usb_product": "PicoPlanet",
+    "variant": "bleeptrack_picoplanet",
+    "zephyr": {
+       "variant": "bleeptrack_picoplanet"
+    }
+  },
+  "debug": {
+    "jlink_device": "ATSAMD21E18",
+    "openocd_chipname": "at91samd21e18",
+    "openocd_target": "at91samdXX",
+    "svd_path": "ATSAMD21E18A.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "zephyr"
+  ],
+  "name": "PicoPlanet by bleeptrack",
+  "upload": {
+    "disable_flushing": true,
+    "maximum_ram_size": 32768,
+    "maximum_size": 262144,
+    "native_usb": true,
+    "offset_address": "0x2000",
+    "protocol": "sam-ba",
+    "protocols": [
+      "sam-ba",
+      "blackmagic",
+      "jlink",
+      "atmel-ice"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": true,
+    "wait_for_upload_port": true
+  },
+  "url": "https://github.com/bleeptrack/picoplanet",
+  "vendor": "bleeptrack"
+}

--- a/example/platformio/include/README
+++ b/example/platformio/include/README
@@ -1,0 +1,39 @@
+
+This directory is intended for project header files.
+
+A header file is a file containing C declarations and macro definitions
+to be shared between several project source files. You request the use of a
+header file in your project source file (C, C++, etc) located in `src` folder
+by including it, with the C preprocessing directive `#include'.
+
+```src/main.c
+
+#include "header.h"
+
+int main (void)
+{
+ ...
+}
+```
+
+Including a header file produces the same results as copying the header file
+into each source file that needs it. Such copying would be time-consuming
+and error-prone. With a header file, the related declarations appear
+in only one place. If they need to be changed, they can be changed in one
+place, and programs that include the header file will automatically use the
+new version when next recompiled. The header file eliminates the labor of
+finding and changing all the copies as well as the risk that a failure to
+find one copy will result in inconsistencies within a program.
+
+In C, the usual convention is to give header files names that end with `.h'.
+It is most portable to use only letters, digits, dashes, and underscores in
+header file names, and at most one dot.
+
+Read more about using header files in official GCC documentation:
+
+* Include Syntax
+* Include Operation
+* Once-Only Headers
+* Computed Includes
+
+https://gcc.gnu.org/onlinedocs/cpp/Header-Files.html

--- a/example/platformio/lib/README
+++ b/example/platformio/lib/README
@@ -1,0 +1,46 @@
+
+This directory is intended for project specific (private) libraries.
+PlatformIO will compile them to static libraries and link into executable file.
+
+The source code of each library should be placed in a an own separate directory
+("lib/your_library_name/[here are source files]").
+
+For example, see a structure of the following two libraries `Foo` and `Bar`:
+
+|--lib
+|  |
+|  |--Bar
+|  |  |--docs
+|  |  |--examples
+|  |  |--src
+|  |     |- Bar.c
+|  |     |- Bar.h
+|  |  |- library.json (optional, custom build options, etc) https://docs.platformio.org/page/librarymanager/config.html
+|  |
+|  |--Foo
+|  |  |- Foo.c
+|  |  |- Foo.h
+|  |
+|  |- README --> THIS FILE
+|
+|- platformio.ini
+|--src
+   |- main.c
+
+and a contents of `src/main.c`:
+```
+#include <Foo.h>
+#include <Bar.h>
+
+int main (void)
+{
+  ...
+}
+
+```
+
+PlatformIO Library Dependency Finder will find automatically dependent
+libraries scanning project source files.
+
+More information about PlatformIO Library Dependency Finder
+- https://docs.platformio.org/page/librarymanager/ldf.html

--- a/example/platformio/platformio.ini
+++ b/example/platformio/platformio.ini
@@ -1,0 +1,22 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[env:bleeptrack_picoplanet]
+platform = atmelsam
+board = bleeptrack_picoplanet
+board_build.variants_dir = variants
+framework = arduino
+board_build.mcu = samd21e18a
+
+lib_deps =
+  adafruit/Adafruit FreeTouch Library @ ^1.1.0
+  https://github.com/NicoHood/HID
+  Wire
+  SPI

--- a/example/platformio/src/main.cpp
+++ b/example/platformio/src/main.cpp
@@ -1,0 +1,190 @@
+#include <Arduino.h>
+#include "Adafruit_FreeTouch.h"
+#include "HID-Project.h"
+#include "Wire.h"
+#include "SPI.h"
+
+Adafruit_FreeTouch qt_1 = Adafruit_FreeTouch(A0, OVERSAMPLE_4, RESISTOR_20K, FREQ_MODE_NONE);
+Adafruit_FreeTouch qt_2 = Adafruit_FreeTouch(A1, OVERSAMPLE_4, RESISTOR_20K, FREQ_MODE_NONE);
+Adafruit_FreeTouch qt_3 = Adafruit_FreeTouch(A2, OVERSAMPLE_4, RESISTOR_20K, FREQ_MODE_NONE);
+
+void ledsOff();
+void flashLED(uint8_t led, uint16_t duration);
+void pulseLED(uint8_t led);
+void pulseWhite();
+void testIO();
+void testUart1();
+void testI2C();
+void testSPI();
+
+void setup() {
+  // HID
+  Keyboard.begin();
+  // Serial
+  Serial.begin(9600);
+  Serial.println("Start!");
+  // Init and test LEDs
+  ledsOff();
+  flashLED(LED_R, 1e3);
+  flashLED(LED_G, 1e3);
+  flashLED(LED_B, 1e3);
+  pulseLED(LED_R);
+  pulseLED(LED_G);
+  pulseLED(LED_B);
+  pulseWhite();
+  ledsOff();
+  
+  // Periperial Tests:
+  //testUart1();
+  //testI2C();
+  //testIO();
+  //testSPI();
+
+  // Init Touch
+  qt_1.begin();
+  qt_2.begin();
+  qt_3.begin();
+}
+
+void loop() {
+  //meassure values at capacitive touch buttons
+  int result1 = qt_1.measure();
+  int result2 = qt_2.measure();
+  int result3 = qt_3.measure();
+  //check if button is pressed aka value is high enough
+  //important: LEDs are active when LOW!
+  if(result1 > 500){
+    digitalWrite(LED_R, LOW);
+    Keyboard.write(KEY_VOLUME_MUTE);
+    Serial.println('R');
+    delay(200);
+  }else{
+    digitalWrite(LED_R, HIGH);
+  }
+
+  if(result2 > 500){
+    digitalWrite(LED_G, LOW);
+    Keyboard.write(KEY_VOLUME_UP);
+    Serial.println('G');
+    delay(200);
+  }else{
+    digitalWrite(LED_G, HIGH);
+  }
+
+  if(result3 > 500){
+    digitalWrite(LED_B, LOW);
+    Keyboard.write(KEY_VOLUME_DOWN);
+    Serial.println('B');
+    delay(200);
+  }else{
+    digitalWrite(LED_B, HIGH);
+  }
+
+}
+
+void ledsOff() {
+  pinMode(LED_R, OUTPUT);
+  pinMode(LED_G, OUTPUT);
+  pinMode(LED_B, OUTPUT);
+  digitalWrite(LED_R,HIGH);
+  digitalWrite(LED_G,HIGH);
+  digitalWrite(LED_B,HIGH); 
+}
+
+void flashLED(uint8_t led, uint16_t duration) {
+  digitalWrite(LED_R,!(LED_R==led));
+  digitalWrite(LED_G,!(LED_G==led));
+  digitalWrite(LED_B,!(LED_B==led));
+  delay(duration);
+  ledsOff();
+}
+
+void pulseLED(uint8_t led) {
+  ledsOff();
+  for(uint8_t i=255; i>0; i--) {
+    analogWrite(led, i);
+    delay(2);
+  }
+  for(uint8_t i=0; i<255; i++) {
+    analogWrite(led, i);
+    delay(2);
+  }
+  ledsOff();
+}
+
+void pulseWhite() {
+  ledsOff();
+  for(uint8_t i=255; i>0; i--) {
+    analogWrite(LED_R, i);
+    analogWrite(LED_G, i);
+    analogWrite(LED_B, i);
+    delay(2);
+  }
+  for(uint8_t i=0; i<255; i++) {
+    analogWrite(LED_R, i);
+    analogWrite(LED_G, i);
+    analogWrite(LED_B, i);
+    delay(2);
+  }
+  ledsOff();
+}
+
+void testIO() {
+  Serial.println("Probe D1-D4 and SWDIO, SWCLK with oscilloscope or piezo.");
+  pinMode(D1,OUTPUT);
+  pinMode(D2,OUTPUT);
+  pinMode(D3,OUTPUT);
+  pinMode(D4,OUTPUT);
+  pinMode(SWDIO,OUTPUT);
+  pinMode(SWCLK,OUTPUT);
+  uint8_t i = 0;
+  while(1) {
+    i++;
+    digitalWrite(D1,(i>>1)&1);
+    digitalWrite(D2,(i>>2)&1);
+    digitalWrite(D3,(i>>3)&1);
+    digitalWrite(D4,(i>>4)&1);
+    digitalWrite(SWDIO,(i>>5)&1);
+    digitalWrite(SWCLK,(i>>6)&1);
+    delay(1);
+  }
+}
+
+void testUart1() {
+  Serial1.begin(9600);
+  while(1) {
+    Serial.print("Connect D1 (TX) and D2 (RX) for loopback; Serial1 Bytes available: ");
+    Serial.println(Serial1.available());
+    Serial1.write("A");
+    delay(1e3);
+  }
+}
+
+void testI2C() {
+  Wire.begin();
+  Serial.println("Sending via I2C D1 (SDA) D2 (SCL)");
+  while(1) {
+    Serial.print(".");
+    Wire.beginTransmission(4); // transmit to device #4
+    Wire.write("beef");        // sends four bytes
+    Wire.endTransmission();    // stop transmitting
+    delay(1e2);
+  }
+}
+
+void testSPI() {
+  SPI.begin();
+  uint8_t val1,cnt=0;
+  SPISettings settings(4000000, MSBFIRST, SPI_MODE0);
+  while(1) {
+    SPI.beginTransaction(settings);
+    val1 = SPI.transfer(0x42);
+    SPI.endTransaction();
+    if(cnt++ == 0) {
+      Serial.print("Test SPI, connect MOSI (D3) and MISO (SWCLK) OR GND and MISO (SWCLK): ");
+      Serial.print(val1, HEX);
+      Serial.println(" ");
+    }
+    delay(2);
+  }
+}

--- a/example/platformio/test/README
+++ b/example/platformio/test/README
@@ -1,0 +1,11 @@
+
+This directory is intended for PlatformIO Unit Testing and project tests.
+
+Unit Testing is a software testing method by which individual units of
+source code, sets of one or more MCU program modules together with associated
+control data, usage procedures, and operating procedures, are tested to
+determine whether they are fit for use. Unit testing finds problems early
+in the development cycle.
+
+More information about PlatformIO Unit Testing:
+- https://docs.platformio.org/page/plus/unit-testing.html

--- a/example/platformio/variants/bleeptrack_picoplanet/debug_scripts/variant.gdb
+++ b/example/platformio/variants/bleeptrack_picoplanet/debug_scripts/variant.gdb
@@ -1,0 +1,31 @@
+#
+#  Arduino Zero OpenOCD script.
+#
+#  Copyright (c) 2014-2015 Arduino LLC. All right reserved.
+#
+#  This library is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 2.1 of the License, or (at your option) any later version.
+#
+#  This library is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#  See the GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with this library; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+
+# Define 'reset' command
+define reset
+
+info reg
+
+break main
+
+# End of 'reset' command
+end
+
+target remote | openocd -c "interface cmsis-dap" -c "set CHIPNAME at91samd21g18" -f target/at91samdXX.cfg -c "gdb_port pipe; log_output openocd.log"

--- a/example/platformio/variants/bleeptrack_picoplanet/linker_scripts/gcc/flash_with_bootloader.ld
+++ b/example/platformio/variants/bleeptrack_picoplanet/linker_scripts/gcc/flash_with_bootloader.ld
@@ -1,0 +1,211 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+/* Linker script to configure memory regions.
+ * Need modifying for a specific board.
+ *   FLASH.ORIGIN: starting address of flash
+ *   FLASH.LENGTH: length of flash
+ *   RAM.ORIGIN: starting address of RAM bank 0
+ *   RAM.LENGTH: length of RAM bank 0
+ */
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x00000000+0x2000, LENGTH = 0x00040000-0x2000 /* First 8KB used by bootloader */
+  RAM (rwx) : ORIGIN = 0x20000000, LENGTH = 0x00008000
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __copy_table_start__
+ *   __copy_table_end__
+ *   __zero_table_start__
+ *   __zero_table_end__
+ *   __etext
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+	.text :
+	{
+		KEEP(*(.isr_vector))
+		*(.text*)
+
+		KEEP(*(.init))
+		KEEP(*(.fini))
+
+		/* .ctors */
+		*crtbegin.o(.ctors)
+		*crtbegin?.o(.ctors)
+		*(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+		*(SORT(.ctors.*))
+		*(.ctors)
+
+		/* .dtors */
+ 		*crtbegin.o(.dtors)
+ 		*crtbegin?.o(.dtors)
+ 		*(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+ 		*(SORT(.dtors.*))
+ 		*(.dtors)
+
+		*(.rodata*)
+
+		KEEP(*(.eh_frame*))
+	} > FLASH
+
+	.ARM.extab :
+	{
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+	} > FLASH
+
+	__exidx_start = .;
+	.ARM.exidx :
+	{
+		*(.ARM.exidx* .gnu.linkonce.armexidx.*)
+	} > FLASH
+	__exidx_end = .;
+
+	/* To copy multiple ROM to RAM sections,
+	 * uncomment .copy.table section and,
+	 * define __STARTUP_COPY_MULTIPLE in startup_ARMCMx.S */
+	/*
+	.copy.table :
+	{
+		. = ALIGN(4);
+		__copy_table_start__ = .;
+		LONG (__etext)
+		LONG (__data_start__)
+		LONG (__data_end__ - __data_start__)
+		LONG (__etext2)
+		LONG (__data2_start__)
+		LONG (__data2_end__ - __data2_start__)
+		__copy_table_end__ = .;
+	} > FLASH
+	*/
+
+	/* To clear multiple BSS sections,
+	 * uncomment .zero.table section and,
+	 * define __STARTUP_CLEAR_BSS_MULTIPLE in startup_ARMCMx.S */
+	/*
+	.zero.table :
+	{
+		. = ALIGN(4);
+		__zero_table_start__ = .;
+		LONG (__bss_start__)
+		LONG (__bss_end__ - __bss_start__)
+		LONG (__bss2_start__)
+		LONG (__bss2_end__ - __bss2_start__)
+		__zero_table_end__ = .;
+	} > FLASH
+	*/
+
+	__etext = .;
+
+	.data : AT (__etext)
+	{
+		__data_start__ = .;
+		*(vtable)
+		*(.data*)
+
+		. = ALIGN(4);
+		/* preinit data */
+		PROVIDE_HIDDEN (__preinit_array_start = .);
+		KEEP(*(.preinit_array))
+		PROVIDE_HIDDEN (__preinit_array_end = .);
+
+		. = ALIGN(4);
+		/* init data */
+		PROVIDE_HIDDEN (__init_array_start = .);
+		KEEP(*(SORT(.init_array.*)))
+		KEEP(*(.init_array))
+		PROVIDE_HIDDEN (__init_array_end = .);
+
+
+		. = ALIGN(4);
+		/* finit data */
+		PROVIDE_HIDDEN (__fini_array_start = .);
+		KEEP(*(SORT(.fini_array.*)))
+		KEEP(*(.fini_array))
+		PROVIDE_HIDDEN (__fini_array_end = .);
+
+		KEEP(*(.jcr*))
+		. = ALIGN(4);
+		/* All data end */
+		__data_end__ = .;
+
+	} > RAM
+
+	.bss :
+	{
+		. = ALIGN(4);
+		__bss_start__ = .;
+		*(.bss*)
+		*(COMMON)
+		. = ALIGN(4);
+		__bss_end__ = .;
+	} > RAM
+
+	.heap (COPY):
+	{
+		__end__ = .;
+		PROVIDE(end = .);
+		*(.heap*)
+		__HeapLimit = .;
+	} > RAM
+
+	/* .stack_dummy section doesn't contains any symbols. It is only
+	 * used for linker to calculate size of stack sections, and assign
+	 * values to stack symbols later */
+	.stack_dummy (COPY):
+	{
+		*(.stack*)
+	} > RAM
+
+	/* Set stack top to end of RAM, and stack limit move down by
+	 * size of stack_dummy section */
+	__StackTop = ORIGIN(RAM) + LENGTH(RAM);
+	__StackLimit = __StackTop - SIZEOF(.stack_dummy);
+	PROVIDE(__stack = __StackTop);
+
+	__ram_end__ = ORIGIN(RAM) + LENGTH(RAM) -1 ;
+
+	/* Check if data + heap + stack exceeds RAM limit */
+	ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/example/platformio/variants/bleeptrack_picoplanet/linker_scripts/gcc/flash_without_bootloader.ld
+++ b/example/platformio/variants/bleeptrack_picoplanet/linker_scripts/gcc/flash_without_bootloader.ld
@@ -1,0 +1,212 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+/* Linker script to configure memory regions.
+ * Need modifying for a specific board.
+ *   FLASH.ORIGIN: starting address of flash
+ *   FLASH.LENGTH: length of flash
+ *   RAM.ORIGIN: starting address of RAM bank 0
+ *   RAM.LENGTH: length of RAM bank 0
+ */
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 0x00040000
+  RAM (rwx) : ORIGIN = 0x20000000, LENGTH = 0x00008000
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __copy_table_start__
+ *   __copy_table_end__
+ *   __zero_table_start__
+ *   __zero_table_end__
+ *   __etext
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ *   __ram_end__
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+	.text :
+	{
+		KEEP(*(.isr_vector))
+		*(.text*)
+
+		KEEP(*(.init))
+		KEEP(*(.fini))
+
+		/* .ctors */
+		*crtbegin.o(.ctors)
+		*crtbegin?.o(.ctors)
+		*(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+		*(SORT(.ctors.*))
+		*(.ctors)
+
+		/* .dtors */
+ 		*crtbegin.o(.dtors)
+ 		*crtbegin?.o(.dtors)
+ 		*(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+ 		*(SORT(.dtors.*))
+ 		*(.dtors)
+
+		*(.rodata*)
+
+		KEEP(*(.eh_frame*))
+	} > FLASH
+
+	.ARM.extab :
+	{
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+	} > FLASH
+
+	__exidx_start = .;
+	.ARM.exidx :
+	{
+		*(.ARM.exidx* .gnu.linkonce.armexidx.*)
+	} > FLASH
+	__exidx_end = .;
+
+	/* To copy multiple ROM to RAM sections,
+	 * uncomment .copy.table section and,
+	 * define __STARTUP_COPY_MULTIPLE in startup_ARMCMx.S */
+	/*
+	.copy.table :
+	{
+		. = ALIGN(4);
+		__copy_table_start__ = .;
+		LONG (__etext)
+		LONG (__data_start__)
+		LONG (__data_end__ - __data_start__)
+		LONG (__etext2)
+		LONG (__data2_start__)
+		LONG (__data2_end__ - __data2_start__)
+		__copy_table_end__ = .;
+	} > FLASH
+	*/
+
+	/* To clear multiple BSS sections,
+	 * uncomment .zero.table section and,
+	 * define __STARTUP_CLEAR_BSS_MULTIPLE in startup_ARMCMx.S */
+	/*
+	.zero.table :
+	{
+		. = ALIGN(4);
+		__zero_table_start__ = .;
+		LONG (__bss_start__)
+		LONG (__bss_end__ - __bss_start__)
+		LONG (__bss2_start__)
+		LONG (__bss2_end__ - __bss2_start__)
+		__zero_table_end__ = .;
+	} > FLASH
+	*/
+
+	__etext = .;
+
+	.data : AT (__etext)
+	{
+		__data_start__ = .;
+		*(vtable)
+		*(.data*)
+
+		. = ALIGN(4);
+		/* preinit data */
+		PROVIDE_HIDDEN (__preinit_array_start = .);
+		KEEP(*(.preinit_array))
+		PROVIDE_HIDDEN (__preinit_array_end = .);
+
+		. = ALIGN(4);
+		/* init data */
+		PROVIDE_HIDDEN (__init_array_start = .);
+		KEEP(*(SORT(.init_array.*)))
+		KEEP(*(.init_array))
+		PROVIDE_HIDDEN (__init_array_end = .);
+
+
+		. = ALIGN(4);
+		/* finit data */
+		PROVIDE_HIDDEN (__fini_array_start = .);
+		KEEP(*(SORT(.fini_array.*)))
+		KEEP(*(.fini_array))
+		PROVIDE_HIDDEN (__fini_array_end = .);
+
+		KEEP(*(.jcr*))
+		. = ALIGN(4);
+		/* All data end */
+		__data_end__ = .;
+
+	} > RAM
+
+	.bss :
+	{
+		. = ALIGN(4);
+		__bss_start__ = .;
+		*(.bss*)
+		*(COMMON)
+		. = ALIGN(4);
+		__bss_end__ = .;
+	} > RAM
+
+	.heap (COPY):
+	{
+		__end__ = .;
+		PROVIDE(end = .);
+		*(.heap*)
+		__HeapLimit = .;
+	} > RAM
+
+	/* .stack_dummy section doesn't contains any symbols. It is only
+	 * used for linker to calculate size of stack sections, and assign
+	 * values to stack symbols later */
+	.stack_dummy (COPY):
+	{
+		*(.stack*)
+	} > RAM
+
+	/* Set stack top to end of RAM, and stack limit move down by
+	 * size of stack_dummy section */
+	__StackTop = ORIGIN(RAM) + LENGTH(RAM) ;
+	__StackLimit = __StackTop - SIZEOF(.stack_dummy);
+	PROVIDE(__stack = __StackTop);
+
+	__ram_end__ = ORIGIN(RAM) + LENGTH(RAM) -1 ;
+
+	/* Check if data + heap + stack exceeds RAM limit */
+	ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/example/platformio/variants/bleeptrack_picoplanet/openocd_scripts/trinket_m0.cfg
+++ b/example/platformio/variants/bleeptrack_picoplanet/openocd_scripts/trinket_m0.cfg
@@ -1,0 +1,28 @@
+#
+#  Adafruit Trinket M0 OpenOCD script.
+#
+#  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+#
+#  This library is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 2.1 of the License, or (at your option) any later version.
+#
+#  This library is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#  See the GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with this library; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+
+# chip name
+set CHIPNAME at91samd21g18
+set ENDIAN little
+
+# choose a port here
+set telnet_port 0
+
+source [find target/at91samdXX.cfg]

--- a/example/platformio/variants/bleeptrack_picoplanet/pins_arduino.h
+++ b/example/platformio/variants/bleeptrack_picoplanet/pins_arduino.h
@@ -1,0 +1,21 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+// API compatibility
+#include "variant.h"
+

--- a/example/platformio/variants/bleeptrack_picoplanet/variant.cpp
+++ b/example/platformio/variants/bleeptrack_picoplanet/variant.cpp
@@ -1,0 +1,89 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "variant.h"
+
+/*
+ * Pins descriptions
+ */
+const PinDescription g_APinDescription[]=
+{
+  // Based on https://github.com/adafruit/ArduinoCore-samd/blob/master/variants/trinket_m0/variant.cpp
+  // and Atmel SAM D21E / SAM D21G / SAM D21J [DATASHEET] Table 7-1. PORT Function Multiplexing (Page 31)
+  // PicoPlanet Board Layout:
+  // LABEL           PIN    SERCOM            SERCOM_ALT
+  // D1,A3,SDA,TX    PA08   SERCOM0 PAD 0     SERCOM2 PAD 0
+  // D2,A4,SCL,RX    PA09   SERCOM0 PAD 1     SERCOM2 PAD 1
+  // D3,MOSI         PA16   SERCOM1 PAD 0     SERCOM3 PAD 0
+  // D4,SCK          PA17   SERCOM1 PAD 1     SERCOM3 PAD 1
+  // D5,LED_G        PA05
+  // D6,LED_R        PA06
+  // D7,LED_B        PA07
+  // A0,TOUCH1       PA03
+  // A1,TOUCH2       PA02
+  // A2,TOUCH3       PA04
+  // SWCLK,MISO      PA30                     SERCOM1 PAD 2
+  // SWDIO           PA31                     SERCOM1 PAD 3
+
+  // 0, NC
+  { NOT_A_PORT, 99, PIO_NOT_A_PIN, (PIN_ATTR_NONE), No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE },
+  // 1-7, D1-D7, I2C via SERCOM2, SPI via SERCOM1
+  { PORTA,  8, PIO_SERCOM_ALT, (PIN_ATTR_DIGITAL|PIN_ATTR_ANALOG|PIN_ATTR_PWM|PIN_ATTR_TIMER), ADC_Channel16, PWM0_CH0, TCC0_CH0, EXTERNAL_INT_NMI },
+  { PORTA,  9, PIO_SERCOM_ALT, (PIN_ATTR_DIGITAL|PIN_ATTR_ANALOG|PIN_ATTR_PWM|PIN_ATTR_TIMER), ADC_Channel17, PWM0_CH1, TCC0_CH1, EXTERNAL_INT_9 },
+  { PORTA, 16, PIO_SERCOM, (PIN_ATTR_DIGITAL), No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE },
+  { PORTA, 17, PIO_SERCOM, (PIN_ATTR_DIGITAL), No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE },
+  { PORTA,  5, PIO_DIGITAL, (PIN_ATTR_DIGITAL|PIN_ATTR_ANALOG|PIN_ATTR_PWM|PIN_ATTR_TIMER), ADC_Channel5, PWM0_CH1, TCC0_CH1, EXTERNAL_INT_5 },
+  { PORTA,  6, PIO_DIGITAL, (PIN_ATTR_DIGITAL|PIN_ATTR_ANALOG|PIN_ATTR_PWM|PIN_ATTR_TIMER), ADC_Channel6, PWM1_CH0, TCC1_CH0, EXTERNAL_INT_6 },
+  { PORTA,  7, PIO_DIGITAL, (PIN_ATTR_DIGITAL|PIN_ATTR_ANALOG|PIN_ATTR_PWM|PIN_ATTR_TIMER), ADC_Channel7, PWM1_CH1, TCC1_CH1, EXTERNAL_INT_7 },
+  // 8-12, A0-A4
+  { PORTA,  3, PIO_ANALOG, (PIN_ATTR_ANALOG|PIN_ATTR_DIGITAL), ADC_Channel1, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_3 },
+  { PORTA,  2, PIO_ANALOG, (PIN_ATTR_ANALOG|PIN_ATTR_DIGITAL), ADC_Channel0, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_2 },
+  { PORTA,  4, PIO_ANALOG, (PIN_ATTR_ANALOG|PIN_ATTR_DIGITAL), ADC_Channel2, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_4 },
+  { PORTA,  8, PIO_ANALOG, (PIN_ATTR_ANALOG|PIN_ATTR_DIGITAL|PIN_ATTR_PWM|PIN_ATTR_TIMER), ADC_Channel16, PWM0_CH0, TCC0_CH0, EXTERNAL_INT_NMI },
+  { PORTA,  9, PIO_ANALOG, (PIN_ATTR_ANALOG|PIN_ATTR_DIGITAL|PIN_ATTR_PWM|PIN_ATTR_TIMER), ADC_Channel17, PWM0_CH1, TCC0_CH1, EXTERNAL_INT_9 },
+  // 13, Typically an LED, so use PA07 (D7/LED_B) once again
+  { PORTA,  7, PIO_DIGITAL, (PIN_ATTR_DIGITAL|PIN_ATTR_ANALOG|PIN_ATTR_PWM|PIN_ATTR_TIMER), ADC_Channel7, PWM1_CH1, TCC1_CH1, EXTERNAL_INT_7 },
+  // 14-15
+  { NOT_A_PORT, 99, PIO_NOT_A_PIN, (PIN_ATTR_NONE), No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE },
+  { NOT_A_PORT, 99, PIO_NOT_A_PIN, (PIN_ATTR_NONE), No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE },
+  // 16-18, USB
+  { PORTA, 28, PIO_COM, PIN_ATTR_NONE, No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE }, // USB Host enable
+  { PORTA, 24, PIO_COM, PIN_ATTR_NONE, No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE }, // USB/DM
+  { PORTA, 25, PIO_COM, PIN_ATTR_NONE, No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE }, // USB/DP
+  // 19-20, SWCLK & SWDIO, SPI via SERCOM1
+  { PORTA, 30, PIO_SERCOM_ALT, PIN_ATTR_NONE, No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE },
+  { PORTA, 31, PIO_SERCOM_ALT, PIN_ATTR_NONE, No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE },
+  // 21-22, UART via SERCOM0 on D1,D2
+  { PORTA,  8, PIO_SERCOM, (PIN_ATTR_DIGITAL|PIN_ATTR_PWM|PIN_ATTR_TIMER), ADC_Channel16, PWM0_CH0, TCC0_CH0, EXTERNAL_INT_NMI },
+  { PORTA,  9, PIO_SERCOM, (PIN_ATTR_DIGITAL|PIN_ATTR_PWM|PIN_ATTR_TIMER), ADC_Channel17, PWM0_CH1, TCC0_CH1, EXTERNAL_INT_9 },
+} ;
+
+const void* g_apTCInstances[TCC_INST_NUM+TC_INST_NUM]={ TCC0, TCC1, TCC2, TC3, TC4, TC5 } ;
+
+// Multi-serial objects instantiation
+SERCOM sercom0( SERCOM0 ) ;
+SERCOM sercom1( SERCOM1 ) ;
+SERCOM sercom2( SERCOM2 ) ;
+SERCOM sercom3( SERCOM3 ) ;
+
+Uart Serial1( &sercom0, PIN_SERIAL1_RX, PIN_SERIAL1_TX, PAD_SERIAL1_RX, PAD_SERIAL1_TX ) ;
+
+void SERCOM0_Handler()
+{
+  Serial1.IrqHandler();
+}

--- a/example/platformio/variants/bleeptrack_picoplanet/variant.h
+++ b/example/platformio/variants/bleeptrack_picoplanet/variant.h
@@ -1,0 +1,217 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifndef _VARIANT_ARDUINO_ZERO_
+#define _VARIANT_ARDUINO_ZERO_
+
+// The definitions here needs a SAMD core >=1.6.6
+#define ARDUINO_SAMD_VARIANT_COMPLIANCE 10606
+
+/*----------------------------------------------------------------------------
+ *        Definitions
+ *----------------------------------------------------------------------------*/
+
+/** Frequency of the board main oscillator */
+#define VARIANT_MAINOSC		(32768ul)
+
+/** Master clock frequency */
+#define VARIANT_MCK	(F_CPU)
+
+/*----------------------------------------------------------------------------
+ *        Headers
+ *----------------------------------------------------------------------------*/
+
+#include "WVariant.h"
+
+#ifdef __cplusplus
+#include "SERCOM.h"
+#include "Uart.h"
+#endif // __cplusplus
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif // __cplusplus
+
+/*----------------------------------------------------------------------------
+ *        Pins
+ *----------------------------------------------------------------------------*/
+
+// Number of pins defined in PinDescription array
+#define PINS_COUNT           (22u)
+#define NUM_DIGITAL_PINS     (22u)
+#define NUM_ANALOG_INPUTS    (5u)
+#define NUM_ANALOG_OUTPUTS   (1u)
+#define analogInputToDigitalPin(p)  ((p < 5u) ? (p) + PIN_A0 : -1)
+
+#define digitalPinToPort(P)        ( &(PORT->Group[g_APinDescription[P].ulPort]) )
+#define digitalPinToBitMask(P)     ( 1 << g_APinDescription[P].ulPin )
+//#define analogInPinToBit(P)        ( )
+#define portOutputRegister(port)   ( &(port->OUT.reg) )
+#define portInputRegister(port)    ( &(port->IN.reg) )
+#define portModeRegister(port)     ( &(port->DIR.reg) )
+#define digitalPinHasPWM(P)        ( g_APinDescription[P].ulPWMChannel != NOT_ON_PWM || g_APinDescription[P].ulTCChannel != NOT_ON_TIMER )
+
+/*
+ * digitalPinToTimer(..) is AVR-specific and is not defined for SAMD
+ * architecture. If you need to check if a pin supports PWM you must
+ * use digitalPinHasPWM(..).
+ *
+ * https://github.com/arduino/Arduino/issues/1833
+ */
+// #define digitalPinToTimer(P)
+
+// PINs
+#define D1 1
+#define D2 2
+#define D3 3
+#define D4 4
+#define D5 5
+#define D6 6
+#define D7 7
+#define PIN_NC 0
+#define SWCLK                (19u)
+#define SWDIO                (20u)
+
+// LEDs
+#define LED_G                D5
+#define LED_R                D6
+#define LED_B                D7
+#define PIN_LED_13           LED_B
+#define PIN_LED_RXL          PIN_NC // or LED_G if you want it to flash with Serial()
+#define PIN_LED_TXL          PIN_NC // or LED_R if you want it to flash with Serial()
+#define PIN_LED              LED_B
+#define PIN_LED2             LED_R
+#define PIN_LED3             LED_G
+#define LED_BUILTIN          LED_B
+
+/*
+ * Analog pins
+ */
+#define PIN_A0               (8ul)
+#define PIN_A1               (PIN_A0 + 1)
+#define PIN_A2               (PIN_A0 + 2)
+#define PIN_A3               (PIN_A0 + 3)
+#define PIN_A4               (PIN_A0 + 4)
+#define PIN_DAC0             PIN_A0
+#define TOUCH1               PIN_A0
+#define TOUCH2               PIN_A1
+#define TOUCH3               PIN_A2
+
+static const uint8_t A0  = PIN_A0;
+static const uint8_t A1  = PIN_A1;
+static const uint8_t A2  = PIN_A2;
+static const uint8_t A3  = PIN_A3;
+static const uint8_t A4  = PIN_A4;
+static const uint8_t DAC0 = PIN_DAC0;
+
+#define ADC_RESOLUTION		12
+
+/*
+ * Serial interfaces
+ */
+
+// Serial1 (sercom 0)
+#define PIN_SERIAL1_RX       (22u)
+#define PAD_SERIAL1_RX       SERCOM_RX_PAD_1
+#define PIN_SERIAL1_TX       (21u)
+#define PAD_SERIAL1_TX       UART_TX_PAD_0
+
+/*
+ * SPI Interfaces
+ */
+#define SPI_INTERFACES_COUNT 1 // shared with I2C/UART (can't do both)
+
+#define PIN_SPI_MISO         (19u)
+#define PIN_SPI_MOSI         (3u)
+#define PIN_SPI_SCK          (4u)
+#define PERIPH_SPI           sercom1
+#define PAD_SPI_TX           SPI_PAD_0_SCK_1
+#define PAD_SPI_RX           SERCOM_RX_PAD_2
+
+static const uint8_t SS	  = PIN_NC ;
+static const uint8_t MOSI = PIN_SPI_MOSI ;
+static const uint8_t MISO = PIN_SPI_MISO ;
+static const uint8_t SCK  = PIN_SPI_SCK ;
+
+/*
+ * Wire Interfaces
+ */
+#define WIRE_INTERFACES_COUNT 1
+
+#define PIN_WIRE_SDA         (1u)
+#define PIN_WIRE_SCL         (2u)
+#define PERIPH_WIRE          sercom2
+#define WIRE_IT_HANDLER      SERCOM2_Handler
+
+static const uint8_t SDA = PIN_WIRE_SDA;
+static const uint8_t SCL = PIN_WIRE_SCL;
+
+/*
+ * USB
+ */
+#define PIN_USB_HOST_ENABLE (16ul)
+#define PIN_USB_DM          (17ul)
+#define PIN_USB_DP          (18ul)
+
+#ifdef __cplusplus
+}
+#endif
+
+/*----------------------------------------------------------------------------
+ *        Arduino objects - C++ only
+ *----------------------------------------------------------------------------*/
+
+#ifdef __cplusplus
+
+/*	=========================
+ *	===== SERCOM DEFINITION
+ *	=========================
+*/
+extern SERCOM sercom0;
+extern SERCOM sercom1;
+extern SERCOM sercom2;
+extern SERCOM sercom3;
+
+extern Uart Serial1;
+
+#endif
+
+// These serial port names are intended to allow libraries and architecture-neutral
+// sketches to automatically default to the correct port name for a particular type
+// of use.  For example, a GPS module would normally connect to SERIAL_PORT_HARDWARE_OPEN,
+// the first hardware serial port whose RX/TX pins are not dedicated to another use.
+//
+// SERIAL_PORT_MONITOR        Port which normally prints to the Arduino Serial Monitor
+//
+// SERIAL_PORT_USBVIRTUAL     Port which is USB virtual serial
+//
+// SERIAL_PORT_LINUXBRIDGE    Port which connects to a Linux system via Bridge library
+//
+// SERIAL_PORT_HARDWARE       Hardware serial port, physical RX & TX pins.
+//
+// SERIAL_PORT_HARDWARE_OPEN  Hardware serial ports which are open for use.  Their RX & TX
+//                            pins are NOT connected to anything by default.
+#define SERIAL_PORT_USBVIRTUAL      Serial
+#define SERIAL_PORT_MONITOR         Serial
+// Serial has no physical pins broken out, so it's not listed as HARDWARE port
+#define SERIAL_PORT_HARDWARE        Serial1
+#define SERIAL_PORT_HARDWARE_OPEN   Serial1
+
+#endif /* _VARIANT_ARDUINO_ZERO_ */
+

--- a/example/platformio/variants/bleeptrack_picoplanet/variant.h
+++ b/example/platformio/variants/bleeptrack_picoplanet/variant.h
@@ -77,28 +77,43 @@ extern "C"
 // #define digitalPinToTimer(P)
 
 // PINs
-#define D1 1
-#define D2 2
-#define D3 3
-#define D4 4
-#define D5 5
-#define D6 6
-#define D7 7
-#define PIN_NC 0
-#define SWCLK                (19u)
-#define SWDIO                (20u)
+#define PIN_D1                   (1u)
+#define PIN_D2                   (2u)
+#define PIN_D3                   (3u)
+#define PIN_D4                   (4u)
+#define PIN_D5                   (5u)
+#define PIN_D6                   (6u)
+#define PIN_D7                   (7u)
+#define PIN_NC                   (0u)
+#define PIN_SWCLK                (19u)
+#define PIN_SWDIO                (20u)
+
+static const uint8_t D1  = PIN_D1;
+static const uint8_t D2  = PIN_D2;
+static const uint8_t D3  = PIN_D3;
+static const uint8_t D4  = PIN_D4;
+static const uint8_t D5  = PIN_D5;
+static const uint8_t D6  = PIN_D6;
+static const uint8_t D7  = PIN_D7;
+static const uint8_t SWCLK  = PIN_SWCLK;
+static const uint8_t SWDIO  = PIN_SWDIO;
 
 // LEDs
-#define LED_G                D5
-#define LED_R                D6
-#define LED_B                D7
-#define PIN_LED_13           LED_B
-#define PIN_LED_RXL          PIN_NC // or LED_G if you want it to flash with Serial()
-#define PIN_LED_TXL          PIN_NC // or LED_R if you want it to flash with Serial()
-#define PIN_LED              LED_B
-#define PIN_LED2             LED_R
-#define PIN_LED3             LED_G
-#define LED_BUILTIN          LED_B
+#define PIN_LED_G            PIN_D5
+#define PIN_LED_R            PIN_D6
+#define PIN_LED_B            PIN_D7
+#define PIN_LED_13           PIN_LED_R
+#define PIN_LED_RXL          PIN_NC // or LED_x if you want it to flash with Serial()
+#define PIN_LED_TXL          PIN_NC // or LED_x if you want it to flash with Serial()
+#define PIN_LED              PIN_LED_R
+#define PIN_LED2             PIN_LED_G
+#define PIN_LED3             PIN_LED_B
+#define LED_BUILTIN          PIN_LED_R
+
+static const uint8_t LED_R  = PIN_LED_R;
+static const uint8_t LED_G  = PIN_LED_G;
+static const uint8_t LED_B  = PIN_LED_B;
+
 
 /*
  * Analog pins
@@ -135,7 +150,7 @@ static const uint8_t DAC0 = PIN_DAC0;
 /*
  * SPI Interfaces
  */
-#define SPI_INTERFACES_COUNT 1 // shared with I2C/UART (can't do both)
+#define SPI_INTERFACES_COUNT 1
 
 #define PIN_SPI_MISO         (19u)
 #define PIN_SPI_MOSI         (3u)


### PR DESCRIPTION
Adds an example PlatformIO project. 
Since the board is not (yet) officially supported by PlatformIO, the example also contains the needed board variant files to support the picoplanet board.
The board variant also adds support for hardware UART `Serial1` with `TX`/`RX` on `D1`/`D2`.
See #5 for additional discussion.